### PR TITLE
ENG-1675 Update go slave to Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM golang:1.5.3
+FROM golang:1.8.3
 
-RUN wget -O /swarm.jar http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/1.22/swarm-client-1.22-jar-with-dependencies.jar
+RUN wget -O /swarm.jar https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/1.22/swarm-client-1.22-jar-with-dependencies.jar
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 RUN apt-get update
-RUN apt-get -y install openjdk-7-jdk
+RUN apt-get -y install -t jessie-backports openjdk-8-jdk
 
 CMD java -jar /swarm.jar -username $JENKINS_USERNAME -password $JENKINS_APIKEY -labels 'golang swarm'


### PR DESCRIPTION
In order to support a newer version of Jenkins which defaults to java
1.8 and above, the goslave needed to be upgraded to support this.